### PR TITLE
Select UTXOs for rounds 

### DIFF
--- a/WalletWasabi.WabiSabiClientLibrary/Controllers/CryptographyController.cs
+++ b/WalletWasabi.WabiSabiClientLibrary/Controllers/CryptographyController.cs
@@ -9,7 +9,7 @@ using WalletWasabi.WabiSabiClientLibrary.Models;
 using WalletWasabi.Server.Filters;
 using WalletWasabi.WabiSabi.Crypto;
 using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
-
+using WalletWasabi.WabiSabi.Client;
 
 namespace WalletWasabi.WabiSabiClientLibrary.Controllers;
 
@@ -28,6 +28,16 @@ public class CryptographyController : ControllerBase, IDisposable
 	}
 
 	private long MaxAmountCredentialValue { get; }
+
+	/// <summary>
+	/// Given a set of unspent transaction outputs, choose a subset of the outputs that are best to register in a single CoinJoin round according to the given strategy.
+	/// </summary>
+	/// <seealso cref="CoinJoinClient.SelectCoinsForRound"/>
+	[HttpPost("select-utxo-for-round")]
+	public SelectUtxoForRoundResponse SelectUtxoForRound(SelectUtxoForRoundRequest request)
+	{
+		return SelectUtxoForRoundHelper.Select(request);
+	}
 
 	/// <summary>
 	/// Given a set of effective input amounts registered by a participant and a set of effective input amounts

--- a/WalletWasabi.WabiSabiClientLibrary/Controllers/CryptographyController.cs
+++ b/WalletWasabi.WabiSabiClientLibrary/Controllers/CryptographyController.cs
@@ -11,7 +11,7 @@ using WalletWasabi.WabiSabi.Crypto;
 using WalletWasabi.WabiSabi.Crypto.CredentialRequesting;
 
 
-namespace WalletWasabi.WabiSabiClientLibrary;
+namespace WalletWasabi.WabiSabiClientLibrary.Controllers;
 
 [ApiController]
 [ExceptionTranslate]

--- a/WalletWasabi.WabiSabiClientLibrary/Controllers/Helpers/SelectUtxoForRoundHelper.cs
+++ b/WalletWasabi.WabiSabiClientLibrary/Controllers/Helpers/SelectUtxoForRoundHelper.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using WalletWasabi.Blockchain.TransactionOutputs;
+using WalletWasabi.Crypto.Randomness;
+using WalletWasabi.WabiSabi.Client;
+using WalletWasabi.WabiSabiClientLibrary.Models;
+
+namespace WalletWasabi.WabiSabiClientLibrary.Controllers.Helpers;
+
+public class SelectUtxoForRoundHelper
+{
+	public static SelectUtxoForRoundResponse Select(SelectUtxoForRoundRequest request, WasabiRandom? rnd = null)
+	{
+		rnd ??= SecureRandom.Instance;
+		ImmutableList<ISmartCoin> coins = CoinJoinClient.SelectCoinsForRound<ISmartCoin>(request.Utxos, request.Constants, request.ConsolidationMode, request.AnonScoreTarget, rnd);
+
+		Dictionary<ISmartCoin, int> coinIndices = request.Utxos
+			.Select((x, i) => ((ISmartCoin)x, i))
+			.ToDictionary(x => x.Item1, x => x.Item2);
+
+		// Find corresponding indices for the found coins.
+		int[] indices = coins.Select(c => coinIndices[c]).ToArray();
+
+		return new SelectUtxoForRoundResponse(indices);
+	}
+}

--- a/WalletWasabi.WabiSabiClientLibrary/Models/SelectUtxoForRound/Constants.cs
+++ b/WalletWasabi.WabiSabiClientLibrary/Models/SelectUtxoForRound/Constants.cs
@@ -1,6 +1,7 @@
 using NBitcoin;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Models;
 
@@ -9,10 +10,11 @@ namespace WalletWasabi.WabiSabiClientLibrary.Models.SelectUtxoForRound;
 public record Constants(
 	MoneyRange AllowedInputAmounts,
 	MoneyRange AllowedOutputAmounts,
-	IReadOnlyList<string[]> AllowedInputTypes,
+	IReadOnlyList<string> AllowedInputTypes,
 	CoordinationFeeRate CoordinationFeeRate,
 	FeeRate MiningFeeRate
 ) : IUtxoSelectionParameters
 {
-	public ImmutableSortedSet<ScriptType> AllowedInputScriptTypes { get; init; } = ImmutableSortedSet.Create(ScriptType.P2WPKH);
+	public ImmutableSortedSet<ScriptType> AllowedInputScriptTypes
+		=> AllowedInputTypes.Select(scriptType => Enum.Parse<ScriptType>(scriptType)).ToImmutableSortedSet();
 }

--- a/WalletWasabi.WabiSabiClientLibrary/Models/SelectUtxoForRound/Constants.cs
+++ b/WalletWasabi.WabiSabiClientLibrary/Models/SelectUtxoForRound/Constants.cs
@@ -1,0 +1,18 @@
+using NBitcoin;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using WalletWasabi.WabiSabi.Backend.Rounds;
+using WalletWasabi.WabiSabi.Models;
+
+namespace WalletWasabi.WabiSabiClientLibrary.Models.SelectUtxoForRound;
+
+public record Constants(
+	MoneyRange AllowedInputAmounts,
+	MoneyRange AllowedOutputAmounts,
+	IReadOnlyList<string[]> AllowedInputTypes,
+	CoordinationFeeRate CoordinationFeeRate,
+	FeeRate MiningFeeRate
+) : IUtxoSelectionParameters
+{
+	public ImmutableSortedSet<ScriptType> AllowedInputScriptTypes { get; init; } = ImmutableSortedSet.Create(ScriptType.P2WPKH);
+}

--- a/WalletWasabi.WabiSabiClientLibrary/Models/SelectUtxoForRound/Strategy.cs
+++ b/WalletWasabi.WabiSabiClientLibrary/Models/SelectUtxoForRound/Strategy.cs
@@ -1,0 +1,6 @@
+namespace WalletWasabi.WabiSabiClientLibrary.Models.SelectUtxoForRound;
+
+public enum Strategy
+{
+	ANONYMITY
+}

--- a/WalletWasabi.WabiSabiClientLibrary/Models/SelectUtxoForRound/Utxo.cs
+++ b/WalletWasabi.WabiSabiClientLibrary/Models/SelectUtxoForRound/Utxo.cs
@@ -1,0 +1,18 @@
+using NBitcoin;
+using WalletWasabi.Blockchain.TransactionOutputs;
+
+namespace WalletWasabi.WabiSabiClientLibrary.Models.SelectUtxoForRound;
+
+/// <summary>
+/// Represents a single UTXO.
+/// </summary>
+/// <param name="Value">Value of the UTXO in Bitcoin (not effective value).</param>
+/// <param name="ScriptType">UTXO's script type.</param>
+/// <param name="AnonymitySet">Anonymity set assigned to the UTXO.</param>
+/// <param name="LastCoinjoinTimestamp">The parameter is not currently needed in seconds.</param>
+public record Utxo(string TxId, uint Index, Money Value, ScriptType ScriptType, int AnonymitySet, long LastCoinjoinTimestamp) : ISmartCoin
+{
+	public Money Amount => Value;
+
+	public uint256 TransactionId { get; } = new(TxId);
+}

--- a/WalletWasabi.WabiSabiClientLibrary/Models/SelectUtxoForRoundRequest.cs
+++ b/WalletWasabi.WabiSabiClientLibrary/Models/SelectUtxoForRoundRequest.cs
@@ -1,0 +1,19 @@
+using WalletWasabi.WabiSabiClientLibrary.Models.SelectUtxoForRound;
+
+namespace WalletWasabi.WabiSabiClientLibrary.Models;
+
+/// <summary>
+/// Represents a set of available UTXOs and various parameters to select a set of UTXOs satisfying all conditions for a CoinJoin round.
+/// </summary>
+/// <param name="Utxos">Set of the UTXOs to choose from.</param>
+/// <param name="AnonScoreTarget">Required anonymity score target.</param>
+/// <param name="Constants">Parameters affecting UTXOs selection.</param>
+/// <param name="Strategy">Strategy that is used to select UTXOs.</param>
+/// <param name="ConsolidationMode">This option will likely be removed. We expect value to be <c>false</c>.</param>
+public record SelectUtxoForRoundRequest(
+	Utxo[] Utxos,
+	int AnonScoreTarget,
+	Constants Constants,
+	Strategy Strategy = Strategy.ANONYMITY,
+	bool ConsolidationMode = false
+);

--- a/WalletWasabi.WabiSabiClientLibrary/Models/SelectUtxoForRoundResponse.cs
+++ b/WalletWasabi.WabiSabiClientLibrary/Models/SelectUtxoForRoundResponse.cs
@@ -1,0 +1,9 @@
+namespace WalletWasabi.WabiSabiClientLibrary.Models;
+
+/// <summary>
+/// Response object for <see cref="SelectUtxoForRoundRequest"/>.
+/// </summary>
+/// <param name="Indices">Indices of the selected UTXOs from the corresponding <see cref="SelectUtxoForRoundRequest.Utxos"/> array.</param>
+public record SelectUtxoForRoundResponse(
+	int[] Indices
+);

--- a/WalletWasabi.WabiSabiClientLibrary/Startup.cs
+++ b/WalletWasabi.WabiSabiClientLibrary/Startup.cs
@@ -49,6 +49,8 @@ public class Startup
 		// Register the Swagger generator, defining one or more Swagger documents
 		services.AddSwaggerGen(c =>
 		{
+			c.CustomSchemaIds(type => type.ToString());
+
 			c.SwaggerDoc($"v{Constants.BackendMajorVersion}", new OpenApiInfo
 			{
 				Version = $"v{Constants.BackendMajorVersion}",

--- a/WalletWasabi/Blockchain/TransactionOutputs/ISmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/ISmartCoin.cs
@@ -1,0 +1,16 @@
+using NBitcoin;
+
+namespace WalletWasabi.Blockchain.TransactionOutputs;
+
+public interface ISmartCoin
+{
+	Money Amount { get; }
+
+	ScriptType ScriptType { get; }
+
+	int AnonymitySet { get; }
+
+	uint256 TransactionId { get; }
+
+	uint Index { get; }
+}

--- a/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/SmartCoin.cs
@@ -12,7 +12,7 @@ namespace WalletWasabi.Blockchain.TransactionOutputs;
 /// An UTXO that knows more.
 /// </summary>
 [DebuggerDisplay("{Amount}BTC {Confirmed} {HdPubKey.Label} OutPoint={Coin.Outpoint}")]
-public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDestination
+public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDestination, ISmartCoin
 {
 	private Height _height;
 	private SmartTransaction? _spenderTransaction;
@@ -60,7 +60,9 @@ public class SmartCoin : NotifyPropertyChangedBase, IEquatable<SmartCoin>, IDest
 	public Coin Coin => _coin.Value;
 
 	public Script ScriptPubKey => TxOut.ScriptPubKey;
+	public ScriptType ScriptType => ScriptPubKey.GetScriptType() ?? throw new NotSupportedException("Unknown script type.");
 	public Money Amount => TxOut.Value;
+	public int AnonymitySet => HdPubKey.AnonymitySet;
 
 	public Height Height
 	{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/RoundParameters.cs
@@ -8,7 +8,7 @@ using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 
 namespace WalletWasabi.WabiSabi.Backend.Rounds;
 
-public record RoundParameters
+public record RoundParameters : IUtxoSelectionParameters
 {
 	public static ImmutableSortedSet<ScriptType> OnlyP2WPKH = ImmutableSortedSet.Create(ScriptType.P2WPKH);
 

--- a/WalletWasabi/WabiSabi/Backend/Rounds/UtxoSelectionParameters.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/UtxoSelectionParameters.cs
@@ -1,0 +1,15 @@
+using NBitcoin;
+using System.Collections.Immutable;
+using WalletWasabi.WabiSabi.Models;
+
+namespace WalletWasabi.WabiSabi.Backend.Rounds;
+
+public interface IUtxoSelectionParameters
+{
+	MoneyRange AllowedInputAmounts { get; }
+	MoneyRange AllowedOutputAmounts { get; }
+	CoordinationFeeRate CoordinationFeeRate { get; }
+	FeeRate MiningFeeRate { get; }
+
+	ImmutableSortedSet<ScriptType> AllowedInputScriptTypes { get; }
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -434,7 +434,7 @@ public class CoinJoinClient
 		roundState.LogDebug(string.Join(Environment.NewLine, summary));
 	}
 
-	public static ImmutableList<TCoin> SelectCoinsForRound<TCoin>(IEnumerable<TCoin> coins, RoundParameters parameters, bool consolidationMode, int anonScoreTarget, WasabiRandom rnd)
+	public static ImmutableList<TCoin> SelectCoinsForRound<TCoin>(IEnumerable<TCoin> coins, IUtxoSelectionParameters parameters, bool consolidationMode, int anonScoreTarget, WasabiRandom rnd)
 		where TCoin : class, ISmartCoin
 	{
 		TCoin[] filteredCoins = coins
@@ -531,7 +531,7 @@ public class CoinJoinClient
 		return finalCandidate?.ToShuffled()?.ToImmutableList() ?? ImmutableList<TCoin>.Empty;
 	}
 
-	private static bool TryAddGroup<TCoin>(RoundParameters parameters, Dictionary<int, IEnumerable<TCoin>> groups, IEnumerable<TCoin> group)
+	private static bool TryAddGroup<TCoin>(IUtxoSelectionParameters parameters, Dictionary<int, IEnumerable<TCoin>> groups, IEnumerable<TCoin> group)
 		where TCoin : ISmartCoin
 	{
 		var inSum = group.Sum(x => x.EffectiveValue(parameters.MiningFeeRate, parameters.CoordinationFeeRate));


### PR DESCRIPTION
Rebased (needed particularly because of https://github.com/zkSNACKs/WalletWasabi/pull/7860 and https://github.com/zkSNACKs/WalletWasabi/pull/8025) + partial impl for the `SelectUtxoForRound` API method.

* Missing tests
* `Utxo` definition is not matching the current algo.

Also modified `NBitcoinExtensions`, specifically:

```diff
-public static PayToTaprootScriptSigParameters ExtractWitScriptParameters(this PayToTaprootTemplate template, WitScript witScript)
+public static PayToTaprootScriptSigParameters? ExtractWitScriptParameters(this PayToTaprootTemplate template, WitScript witScript)
```

and a few `if`s did not have bodies in braces which is against the code style (and reports errors).